### PR TITLE
Using span<t> as C# equivalence of []T

### DIFF
--- a/arrays/csharp/Program.cs
+++ b/arrays/csharp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace arrays
@@ -12,26 +13,53 @@ namespace arrays
             // Array of int
             // Array lenght must be set a declaration time.
             var series = new int[4] { 1, 2, 5, 7 };
-
+            series.Dump();
             var fruits = new string[3] { "banana", "apple", "pear" };
-
+            fruits.Dump();
             // Slice
             var numbers = new int[4] { 1, 3, 5, 7 };
-            numbers.Append(9);
-            numbers.Append(11);
+            numbers = numbers.Append(9).ToArray();
+            numbers = numbers.Append(11).ToArray();
+            numbers.Dump();
+
+            // Span<T> is the most similar type to Golang's []T.
+            var span = numbers.AsSpan();
 
             // remove first item
-            var slice1 = numbers.Skip(1).ToArray();
+            var slice1 = span.Slice(1);
+            slice1.Dump();
 
             // Get first 3 items
-            var slice2 = numbers.Take(3).ToArray();
+            var slice2 = span[0..3];
+            slice2.Dump();
 
             // Get second and third numbers
-            var segment = new ArraySegment<int>(numbers, 1, 2).ToArray();
+            var segment = span[2..4];
+            segment.Dump();
 
             // Copy the array tyo another 
             var newArray = new int[numbers.Length];
             numbers.CopyTo(newArray, 0);
         }
     }
+
+    static class DumpExtensions {
+        public static void Dump<T>(this IEnumerable<T> col) {
+            Console.Write("[");
+            foreach (var t in col) {
+                Console.Write($"{t},");
+            }
+            Console.Write("]\n");
+        }
+
+        public static void Dump<T>(this Span<T> col) {
+            Console.Write("[");
+            foreach (var t in col) {
+                Console.Write($"{t},");
+            }
+            Console.Write("]\n");
+        }
+
+    }
+
 }

--- a/arrays/csharp/arrays.csproj
+++ b/arrays/csharp/arrays.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the "arrays" sample to use Span<T> as the equivalent type of Golang's []T

Also, to simplify slicing operations over Span<T> the range operator has been used, so language version selected was C# 8.0. To automatically use C# 8.0 and avoid any error, project has been upgraded to netcore3.